### PR TITLE
feat: drop support for php < 8, add string types, add german translation, minor fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [7.4, 8.0, 8.1]
-        deps: [hightest]
+        php: [8.0, 8.1]
+        deps: [highest]
         symfony: [5.4.*]
         include:
-          - php: 7.4
+          - php: 8.0
             deps: lowest
             symfony: '*'
           - php: 8.0

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ referer URLs. When a redirect is created or updated, 404 records that match it's
         $ composer require zenstruck/redirect-bundle
 
 2. Enable the bundle:
+   This Step is only needed if you are not using [Symfony Flex](https://symfony.com/doc/current/setup/flex.html).
 
     ```php
     // config/bundles.php
@@ -70,6 +71,7 @@ referer URLs. When a redirect is created or updated, 404 records that match it's
 3. Update your schema (or use a migration):
 
         $ bin/console doctrine:schema:update --force
+   
 
 ### NotFound
 
@@ -136,6 +138,6 @@ zenstruck_redirect:
     not_found_class:    ~ # Required if redirect_class is not set
     model_manager_name: ~
 
-    # When enabled, when a redirect is updated or created, the NotFound entites with a matching path are removed.
+    # When enabled, when a redirect is updated or created, the NotFound entities with a matching path are removed.
     remove_not_founds: true
 ```

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.0",
         "doctrine/doctrine-bundle": "^2.0",
         "doctrine/orm": "^2.6",
         "symfony/framework-bundle": "^5.4|^6.0"
     },
     "require-dev": {
-        "matthiasnoback/symfony-dependency-injection-test": "^4.1",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.3",
         "symfony/browser-kit": "^5.4|^6.0",
         "symfony/form": "^5.4|^6.0",
         "symfony/phpunit-bridge": "^6.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,28 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
-         failOnWarning="true"
->
-    <php>
-        <ini name="error_reporting" value="-1" />
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
-    </php>
-
-    <testsuites>
-        <testsuite name="Project Test Suite">
-            <directory>./tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./src/</directory>
-        </whitelist>
-    </filter>
+         failOnWarning="true">
+  <coverage>
+    <include>
+      <directory>./src/</directory>
+    </include>
+  </coverage>
+  <php>
+    <ini name="error_reporting" value="-1"/>
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
+  </php>
+  <testsuites>
+    <testsuite name="Project Test Suite">
+      <directory>./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -10,16 +10,11 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('zenstruck_redirect');
 
-        // Keep compatibility with symfony/config < 4.2
-        if (\method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->getRootNode();
-        } else {
-            $rootNode = $treeBuilder->root('zenstruck_redirect');
-        }
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/DependencyInjection/ZenstruckRedirectExtension.php
+++ b/src/DependencyInjection/ZenstruckRedirectExtension.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
  */
 class ZenstruckRedirectExtension extends ConfigurableExtension
 {
-    protected function loadInternal(array $mergedConfig, ContainerBuilder $container)
+    protected function loadInternal(array $mergedConfig, ContainerBuilder $container): void
     {
         if (null === $mergedConfig['redirect_class'] && null === $mergedConfig['not_found_class']) {
             throw new InvalidConfigurationException('A "redirect_class" or "not_found_class" must be set for "zenstruck_redirect".');

--- a/src/EventListener/CreateNotFoundListener.php
+++ b/src/EventListener/CreateNotFoundListener.php
@@ -11,7 +11,8 @@ use Zenstruck\RedirectBundle\Service\NotFoundManager;
 class CreateNotFoundListener extends NotFoundListener
 {
     public function __construct(private NotFoundManager $notFoundManager)
-    {}
+    {
+    }
 
     public function onKernelException(ExceptionEvent $event): void
     {

--- a/src/EventListener/CreateNotFoundListener.php
+++ b/src/EventListener/CreateNotFoundListener.php
@@ -10,14 +10,10 @@ use Zenstruck\RedirectBundle\Service\NotFoundManager;
  */
 class CreateNotFoundListener extends NotFoundListener
 {
-    private $notFoundManager;
+    public function __construct(private NotFoundManager $notFoundManager)
+    {}
 
-    public function __construct(NotFoundManager $notFoundManager)
-    {
-        $this->notFoundManager = $notFoundManager;
-    }
-
-    public function onKernelException(ExceptionEvent $event)
+    public function onKernelException(ExceptionEvent $event): void
     {
         if (!$this->isNotFoundException($event)) {
             return;

--- a/src/EventListener/Doctrine/RemoveNotFoundSubscriber.php
+++ b/src/EventListener/Doctrine/RemoveNotFoundSubscriber.php
@@ -13,16 +13,15 @@ use Zenstruck\RedirectBundle\Service\NotFoundManager;
  */
 class RemoveNotFoundSubscriber implements EventSubscriber
 {
-    private $container;
+    private NotFoundManager|null $notFoundManager = null;
 
-    private $notFoundManager;
+    public function __construct(private ContainerInterface $container)
+    {}
 
-    public function __construct(ContainerInterface $container)
-    {
-        $this->container = $container;
-    }
-
-    public function getSubscribedEvents()
+    /**
+     * @inheritdoc
+     */
+    public function getSubscribedEvents(): array
     {
         return [
             'postPersist',
@@ -30,17 +29,17 @@ class RemoveNotFoundSubscriber implements EventSubscriber
         ];
     }
 
-    public function postUpdate(LifecycleEventArgs $args)
+    public function postUpdate(LifecycleEventArgs $args): void
     {
         $this->remoteNotFoundForRedirect($args);
     }
 
-    public function postPersist(LifecycleEventArgs $args)
+    public function postPersist(LifecycleEventArgs $args): void
     {
         $this->remoteNotFoundForRedirect($args);
     }
 
-    private function remoteNotFoundForRedirect(LifecycleEventArgs $args)
+    private function remoteNotFoundForRedirect(LifecycleEventArgs $args): void
     {
         $entity = $args->getObject();
 
@@ -51,10 +50,7 @@ class RemoveNotFoundSubscriber implements EventSubscriber
         $this->getNotFoundManager()->removeForRedirect($entity);
     }
 
-    /**
-     * @return NotFoundManager
-     */
-    private function getNotFoundManager()
+    private function getNotFoundManager(): NotFoundManager
     {
         if (null === $this->notFoundManager) {
             $this->notFoundManager = $this->container->get('zenstruck_redirect.not_found_manager');

--- a/src/EventListener/Doctrine/RemoveNotFoundSubscriber.php
+++ b/src/EventListener/Doctrine/RemoveNotFoundSubscriber.php
@@ -16,11 +16,9 @@ class RemoveNotFoundSubscriber implements EventSubscriber
     private NotFoundManager|null $notFoundManager = null;
 
     public function __construct(private ContainerInterface $container)
-    {}
+    {
+    }
 
-    /**
-     * @inheritdoc
-     */
     public function getSubscribedEvents(): array
     {
         return [

--- a/src/EventListener/NotFoundListener.php
+++ b/src/EventListener/NotFoundListener.php
@@ -11,16 +11,13 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  */
 abstract class NotFoundListener
 {
-    /**
-     * @return bool
-     */
-    public function isNotFoundException(ExceptionEvent $event)
+    public function isNotFoundException(ExceptionEvent $event): bool
     {
-        if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
+        if (HttpKernelInterface::MAIN_REQUEST !== $event->getRequestType()) {
             return false;
         }
 
-        $exception = \method_exists($event, 'getThrowable') ? $event->getThrowable() : $event->getException();
+        $exception = $event->getThrowable();
 
         if (!$exception instanceof HttpException || 404 !== (int) $exception->getStatusCode()) {
             return false;

--- a/src/EventListener/RedirectOnNotFoundListener.php
+++ b/src/EventListener/RedirectOnNotFoundListener.php
@@ -12,7 +12,8 @@ use Zenstruck\RedirectBundle\Service\RedirectManager;
 class RedirectOnNotFoundListener extends NotFoundListener
 {
     public function __construct(private RedirectManager $redirectManager)
-    {}
+    {
+    }
 
     public function onKernelException(ExceptionEvent $event): void
     {

--- a/src/EventListener/RedirectOnNotFoundListener.php
+++ b/src/EventListener/RedirectOnNotFoundListener.php
@@ -11,14 +11,10 @@ use Zenstruck\RedirectBundle\Service\RedirectManager;
  */
 class RedirectOnNotFoundListener extends NotFoundListener
 {
-    private $redirectManager;
+    public function __construct(private RedirectManager $redirectManager)
+    {}
 
-    public function __construct(RedirectManager $redirectManager)
-    {
-        $this->redirectManager = $redirectManager;
-    }
-
-    public function onKernelException(ExceptionEvent $event)
+    public function onKernelException(ExceptionEvent $event): void
     {
         if (!$this->isNotFoundException($event)) {
             return;

--- a/src/Form/Type/RedirectType.php
+++ b/src/Form/Type/RedirectType.php
@@ -12,17 +12,13 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class RedirectType extends AbstractType
 {
-    private $class;
-
     /**
      * @param string $class The Redirect class name
      */
-    public function __construct($class)
-    {
-        $this->class = $class;
-    }
+    public function __construct(private string $class)
+    {}
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('source', null, [
@@ -38,12 +34,12 @@ class RedirectType extends AbstractType
         ;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'zenstruck_redirect';
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $class = $this->class;
 

--- a/src/Form/Type/RedirectType.php
+++ b/src/Form/Type/RedirectType.php
@@ -16,7 +16,8 @@ class RedirectType extends AbstractType
      * @param string $class The Redirect class name
      */
     public function __construct(private string $class)
-    {}
+    {
+    }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/src/Model/NotFound.php
+++ b/src/Model/NotFound.php
@@ -7,32 +7,13 @@ namespace Zenstruck\RedirectBundle\Model;
  */
 abstract class NotFound
 {
-    /**
-     * @var string
-     */
-    protected $path;
+    protected string $path;
 
-    /**
-     * @var string
-     */
-    protected $fullUrl;
+    protected ?\DateTime $timestamp;
 
-    /**
-     * @var \DateTime
-     */
-    protected $timestamp;
+    protected ?string $referer;
 
-    /**
-     * @var string
-     */
-    protected $referer;
-
-    /**
-     * @param string      $path
-     * @param string      $fullUrl
-     * @param string|null $referer
-     */
-    public function __construct($path, $fullUrl, $referer = null, ?\DateTime $timestamp = null)
+    public function __construct(string $path, protected string $fullUrl, ?string $referer = null, ?\DateTime $timestamp = null)
     {
         if (null === $timestamp) {
             $timestamp = new \DateTime('now');
@@ -42,43 +23,35 @@ abstract class NotFound
         $path = !empty($path) ? $path : null;
 
         if (null !== $path) {
-            $path = '/'.\ltrim(\parse_url($path, \PHP_URL_PATH), '/');
+            $parse_url = \parse_url($path, \PHP_URL_PATH);
+
+            if($parse_url != null)
+            {$path = '/'.\ltrim($parse_url, '/');}
+            else
+            {$path = '/';}
         }
 
         $this->path = $path;
-        $this->fullUrl = $fullUrl;
         $this->referer = $referer;
         $this->timestamp = $timestamp;
     }
 
-    /**
-     * @return string
-     */
-    public function getPath()
+    public function getPath(): ?string
     {
         return $this->path;
     }
 
-    /**
-     * @return string
-     */
-    public function getFullUrl()
+    public function getFullUrl(): string
     {
         return $this->fullUrl;
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getTimestamp()
+    public function getTimestamp(): \DateTime
     {
         return $this->timestamp;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getReferer()
+    public function getReferer(): ?string
     {
         return $this->referer;
     }

--- a/src/Model/NotFound.php
+++ b/src/Model/NotFound.php
@@ -25,10 +25,11 @@ abstract class NotFound
         if (null !== $path) {
             $parse_url = \parse_url($path, \PHP_URL_PATH);
 
-            if($parse_url != null)
-            {$path = '/'.\ltrim($parse_url, '/');}
-            else
-            {$path = '/';}
+            if (null != $parse_url) {
+                $path = '/'.\ltrim($parse_url, '/');
+            } else {
+                $path = '/';
+            }
         }
 
         $this->path = $path;

--- a/src/Model/Redirect.php
+++ b/src/Model/Redirect.php
@@ -101,10 +101,11 @@ abstract class Redirect
     {
         $parse_url = \parse_url($path, \PHP_URL_PATH);
 
-        if($parse_url != null)
-        {$value = '/'.\ltrim($parse_url, '/');}
-        else
-        {$value = '/';}
+        if (null != $parse_url) {
+            $value = '/'.\ltrim($parse_url, '/');
+        } else {
+            $value = '/';
+        }
 
         if ($allowQueryString && $query = \parse_url($path, \PHP_URL_QUERY)) {
             $value .= '?'.$query;

--- a/src/Model/Redirect.php
+++ b/src/Model/Redirect.php
@@ -7,66 +7,34 @@ namespace Zenstruck\RedirectBundle\Model;
  */
 abstract class Redirect
 {
-    /**
-     * @var string
-     */
-    protected $source;
+    protected string $source;
 
-    /**
-     * @var string
-     */
-    protected $destination;
+    protected string $destination;
 
-    /**
-     * @var bool
-     */
-    protected $permanent;
+    protected bool $permanent;
 
-    /**
-     * @var int
-     */
-    protected $count = 0;
+    protected int $count = 0;
 
-    /**
-     * @var \DateTime
-     */
-    protected $lastAccessed = null;
+    protected ?\DateTime $lastAccessed = null;
 
-    /**
-     * @param string $source
-     * @param string $destination
-     * @param bool   $permanent
-     */
-    public function __construct($source, $destination, $permanent = true)
+    public function __construct(string $source, string $destination, bool $permanent = true)
     {
         $this->setSource($source);
         $this->setDestination($destination);
         $this->setPermanent($permanent);
     }
 
-    /**
-     * @param string $destination
-     * @param bool   $permanent
-     *
-     * @return static
-     */
-    public static function createFromNotFound(NotFound $notFound, $destination, $permanent = true)
+    public static function createFromNotFound(NotFound $notFound, string $destination, bool $permanent = true): static
     {
         return new static($notFound->getPath(), $destination, $permanent);
     }
 
-    /**
-     * @return string
-     */
-    public function getSource()
+    public function getSource(): string
     {
         return $this->source;
     }
 
-    /**
-     * @param string $source
-     */
-    public function setSource($source)
+    public function setSource(string $source): void
     {
         $source = \trim($source);
         $source = !empty($source) ? $source : null;
@@ -78,18 +46,12 @@ abstract class Redirect
         $this->source = $source;
     }
 
-    /**
-     * @return string
-     */
-    public function getDestination()
+    public function getDestination(): string
     {
         return $this->destination;
     }
 
-    /**
-     * @param string $destination
-     */
-    public function setDestination($destination)
+    public function setDestination(string $destination): void
     {
         $destination = \trim($destination);
         $destination = !empty($destination) ? $destination : null;
@@ -101,50 +63,32 @@ abstract class Redirect
         $this->destination = $destination;
     }
 
-    /**
-     * @return bool
-     */
-    public function isPermanent()
+    public function isPermanent(): bool
     {
         return $this->permanent;
     }
 
-    /**
-     * @param bool $permanent
-     */
-    public function setPermanent($permanent)
+    public function setPermanent(bool $permanent): void
     {
         $this->permanent = $permanent;
     }
 
-    /**
-     * @return int
-     */
-    public function getCount()
+    public function getCount(): int
     {
         return $this->count;
     }
 
-    /**
-     * @param int $amount
-     */
-    public function increaseCount($amount = 1)
+    public function increaseCount(int $amount = 1): void
     {
         $this->count += $amount;
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getLastAccessed()
+    public function getLastAccessed(): ?\DateTime
     {
         return $this->lastAccessed;
     }
 
-    /**
-     * @param \DateTime $time
-     */
-    public function updateLastAccessed(?\DateTime $time = null)
+    public function updateLastAccessed(?\DateTime $time = null): void
     {
         if (null === $time) {
             $time = new \DateTime('now');
@@ -153,15 +97,14 @@ abstract class Redirect
         $this->lastAccessed = $time;
     }
 
-    /**
-     * @param string $path
-     * @param bool   $allowQueryString
-     *
-     * @return string
-     */
-    protected function createAbsoluteUri($path, $allowQueryString = false)
+    protected function createAbsoluteUri(string $path, bool $allowQueryString = false): string
     {
-        $value = '/'.\ltrim(\parse_url($path, \PHP_URL_PATH), '/');
+        $parse_url = \parse_url($path, \PHP_URL_PATH);
+
+        if($parse_url != null)
+        {$value = '/'.\ltrim($parse_url, '/');}
+        else
+        {$value = '/';}
 
         if ($allowQueryString && $query = \parse_url($path, \PHP_URL_QUERY)) {
             $value .= '?'.$query;

--- a/src/Resources/translations/ZenstruckRedirectBundle.de.yml
+++ b/src/Resources/translations/ZenstruckRedirectBundle.de.yml
@@ -1,0 +1,3 @@
+form:
+    source: Quelle
+    destination: Ziel

--- a/src/Resources/translations/validators.de.yml
+++ b/src/Resources/translations/validators.de.yml
@@ -1,0 +1,6 @@
+zenstruck_redirect:
+    source:
+        unique: Diese Quelle ist bereits in Verwendung.
+        blank: Bitte eine Quelle angeben.
+    destination:
+        blank: Bitte ein Ziel angeben.

--- a/src/Service/NotFoundManager.php
+++ b/src/Service/NotFoundManager.php
@@ -16,7 +16,8 @@ class NotFoundManager
      * @param string $class The NotFound class name
      */
     public function __construct(private string $class, private ObjectManager $om)
-    {}
+    {
+    }
 
     public function createFromRequest(Request $request): NotFound
     {

--- a/src/Service/NotFoundManager.php
+++ b/src/Service/NotFoundManager.php
@@ -12,23 +12,13 @@ use Zenstruck\RedirectBundle\Model\Redirect;
  */
 class NotFoundManager
 {
-    private $class;
-
-    private $om;
-
     /**
      * @param string $class The NotFound class name
      */
-    public function __construct($class, ObjectManager $om)
-    {
-        $this->class = $class;
-        $this->om = $om;
-    }
+    public function __construct(private string $class, private ObjectManager $om)
+    {}
 
-    /**
-     * @return NotFound
-     */
-    public function createFromRequest(Request $request)
+    public function createFromRequest(Request $request): NotFound
     {
         $notFound = new $this->class(
             $request->getPathInfo(),
@@ -45,7 +35,7 @@ class NotFoundManager
     /**
      * Deletes NotFound entities for a Redirect's path.
      */
-    public function removeForRedirect(Redirect $redirect)
+    public function removeForRedirect(Redirect $redirect): void
     {
         $notFounds = $this->om->getRepository($this->class)->findBy(['path' => $redirect->getSource()]);
 

--- a/src/Service/RedirectManager.php
+++ b/src/Service/RedirectManager.php
@@ -14,7 +14,8 @@ class RedirectManager
      * @param string $class The Redirect class name
      */
     public function __construct(private string $class, private ObjectManager $om)
-    {}
+    {
+    }
 
     public function findAndUpdate(string $source): ?Redirect
     {

--- a/src/Service/RedirectManager.php
+++ b/src/Service/RedirectManager.php
@@ -10,25 +10,13 @@ use Zenstruck\RedirectBundle\Model\Redirect;
  */
 class RedirectManager
 {
-    private $class;
-
-    private $om;
-
     /**
      * @param string $class The Redirect class name
      */
-    public function __construct($class, ObjectManager $om)
-    {
-        $this->class = $class;
-        $this->om = $om;
-    }
+    public function __construct(private string $class, private ObjectManager $om)
+    {}
 
-    /**
-     * @param string $source
-     *
-     * @return Redirect|null
-     */
-    public function findAndUpdate($source)
+    public function findAndUpdate(string $source): ?Redirect
     {
         /** @var Redirect|null $redirect */
         $redirect = $this->om->getRepository($this->class)->findOneBy(['source' => $source]);

--- a/src/ZenstruckRedirectBundle.php
+++ b/src/ZenstruckRedirectBundle.php
@@ -11,14 +11,14 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class ZenstruckRedirectBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 
         $this->addRegisterMappingsPass($container);
     }
 
-    private function addRegisterMappingsPass(ContainerBuilder $container)
+    private function addRegisterMappingsPass(ContainerBuilder $container): void
     {
         $mappings = [
             \realpath(__DIR__.'/Resources/config/doctrine-mapping') => 'Zenstruck\RedirectBundle\Model',

--- a/tests/DependencyInjection/ZenstruckRedirectExtensionTest.php
+++ b/tests/DependencyInjection/ZenstruckRedirectExtensionTest.php
@@ -117,7 +117,7 @@ class ZenstruckRedirectExtensionTest extends AbstractExtensionTestCase
         $this->load(['not_found_class' => $class]);
     }
 
-    public function invalidClassProvider()
+    public function invalidClassProvider(): array
     {
         return [
             ['Foo\Bar'],

--- a/tests/EventListener/CreateNotFoundListenerTest.php
+++ b/tests/EventListener/CreateNotFoundListenerTest.php
@@ -2,21 +2,23 @@
 
 namespace Zenstruck\RedirectBundle\Tests\EventListener;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Zenstruck\RedirectBundle\EventListener\CreateNotFoundListener;
+use Zenstruck\RedirectBundle\Service\NotFoundManager;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 class CreateNotFoundListenerTest extends NotFoundListenerTest
 {
-    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    /** @var MockObject&NotFoundManager $notFoundManager */
     private $notFoundManager;
 
     protected function setUp(): void
     {
-        $this->notFoundManager = $this->createMock('Zenstruck\RedirectBundle\Service\NotFoundManager', [], [], '', false);
+        $this->notFoundManager = $this->createMock('Zenstruck\RedirectBundle\Service\NotFoundManager');
         $this->listener = new CreateNotFoundListener($this->notFoundManager);
     }
 

--- a/tests/EventListener/CreateNotFoundListenerTest.php
+++ b/tests/EventListener/CreateNotFoundListenerTest.php
@@ -13,7 +13,7 @@ use Zenstruck\RedirectBundle\Service\NotFoundManager;
  */
 class CreateNotFoundListenerTest extends NotFoundListenerTest
 {
-    /** @var MockObject&NotFoundManager $notFoundManager */
+    /** @var MockObject&NotFoundManager */
     private $notFoundManager;
 
     protected function setUp(): void

--- a/tests/EventListener/NotFoundListenerTest.php
+++ b/tests/EventListener/NotFoundListenerTest.php
@@ -14,8 +14,7 @@ use Zenstruck\RedirectBundle\EventListener\NotFoundListener;
  */
 abstract class NotFoundListenerTest extends TestCase
 {
-    /** @var NotFoundListener */
-    protected $listener;
+    protected NotFoundListener $listener;
 
     /**
      * @test
@@ -53,7 +52,7 @@ abstract class NotFoundListenerTest extends TestCase
         $this->assertNull($event->getResponse());
     }
 
-    protected function createEvent(\Exception $exception, ?Request $request = null, $requestType = HttpKernelInterface::MASTER_REQUEST)
+    protected function createEvent(\Exception $exception, ?Request $request = null, $requestType = HttpKernelInterface::MAIN_REQUEST): ExceptionEvent
     {
         return new ExceptionEvent(
             $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface'),

--- a/tests/EventListener/RedirectOnNotFoundListenerTest.php
+++ b/tests/EventListener/RedirectOnNotFoundListenerTest.php
@@ -2,9 +2,11 @@
 
 namespace Zenstruck\RedirectBundle\Tests\EventListener;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Zenstruck\RedirectBundle\EventListener\RedirectOnNotFoundListener;
+use Zenstruck\RedirectBundle\Service\RedirectManager;
 use Zenstruck\RedirectBundle\Tests\Fixture\Bundle\Entity\DummyRedirect;
 
 /**
@@ -12,12 +14,12 @@ use Zenstruck\RedirectBundle\Tests\Fixture\Bundle\Entity\DummyRedirect;
  */
 class RedirectOnNotFoundListenerTest extends NotFoundListenerTest
 {
-    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    /** @var MockObject&RedirectManager $redirectManager */
     private $redirectManager;
 
     protected function setUp(): void
     {
-        $this->redirectManager = $this->createMock('Zenstruck\RedirectBundle\Service\RedirectManager', [], [], '', false);
+        $this->redirectManager = $this->createMock('Zenstruck\RedirectBundle\Service\RedirectManager');
         $this->listener = new RedirectOnNotFoundListener($this->redirectManager);
     }
 

--- a/tests/EventListener/RedirectOnNotFoundListenerTest.php
+++ b/tests/EventListener/RedirectOnNotFoundListenerTest.php
@@ -14,7 +14,7 @@ use Zenstruck\RedirectBundle\Tests\Fixture\Bundle\Entity\DummyRedirect;
  */
 class RedirectOnNotFoundListenerTest extends NotFoundListenerTest
 {
-    /** @var MockObject&RedirectManager $redirectManager */
+    /** @var MockObject&RedirectManager */
     private $redirectManager;
 
     protected function setUp(): void

--- a/tests/Fixture/TestKernel.php
+++ b/tests/Fixture/TestKernel.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpKernel\Kernel;
  */
 class TestKernel extends Kernel
 {
-    public function registerBundles(): array
+    public function registerBundles(): iterable
     {
         return [
             new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
@@ -20,7 +20,7 @@ class TestKernel extends Kernel
         ];
     }
 
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(\sprintf('%s/config.yml', __DIR__));
     }

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -3,8 +3,8 @@
 namespace Zenstruck\RedirectBundle\Tests\Functional;
 
 use Doctrine\ORM\EntityManager;
-use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\NullOutput;
@@ -19,11 +19,9 @@ use Zenstruck\RedirectBundle\Tests\Fixture\TestKernel;
  */
 abstract class FunctionalTest extends WebTestCase
 {
-    /** @var Client */
-    protected $client;
+    protected KernelBrowser $client;
 
-    /** @var EntityManager */
-    protected $em;
+    protected null|EntityManager $em;
 
     protected function setUp(): void
     {
@@ -47,12 +45,7 @@ abstract class FunctionalTest extends WebTestCase
         return TestKernel::class;
     }
 
-    /**
-     * @param string $source
-     *
-     * @return Redirect|null
-     */
-    protected function getRedirect($source)
+    protected function getRedirect(string $source): ?Redirect
     {
         if (null === $redirect = $this->em->getRepository(DummyRedirect::class)->findOneBy(['source' => $source])) {
             return null;
@@ -66,12 +59,12 @@ abstract class FunctionalTest extends WebTestCase
     /**
      * @return NotFound[]
      */
-    protected function getNotFounds()
+    protected function getNotFounds(): array
     {
         return $this->em->getRepository(DummyNotFound::class)->findAll();
     }
 
-    protected function addTestData()
+    protected function addTestData(): void
     {
         $this->em->createQuery('DELETE '.DummyRedirect::class)
             ->execute()

--- a/tests/Functional/RemoveNotFoundSubscriberTest.php
+++ b/tests/Functional/RemoveNotFoundSubscriberTest.php
@@ -10,7 +10,7 @@ use Zenstruck\RedirectBundle\Tests\Fixture\Bundle\Entity\DummyRedirect;
  */
 class RemoveNotFoundSubscriberTest extends FunctionalTest
 {
-    public function addTestData()
+    public function addTestData(): void
     {
         parent::addTestData();
 

--- a/tests/Functional/ValidationTest.php
+++ b/tests/Functional/ValidationTest.php
@@ -20,13 +20,6 @@ class ValidationTest extends FunctionalTest
 
         $this->assertCount(0, $validator->validate(new DummyRedirect('/foo', '/bar')));
 
-        $errors = $validator->validate(new DummyRedirect(null, null));
-        $this->assertCount(2, $errors);
-        $this->assertSame('Please enter a source.', $errors[0]->getMessage());
-        $this->assertSame('source', $errors[0]->getPropertyPath());
-        $this->assertSame('Please enter a destination.', $errors[1]->getMessage());
-        $this->assertSame('destination', $errors[1]->getPropertyPath());
-
         $errors = $validator->validate(new DummyRedirect('/301-redirect', '/foo'));
         $this->assertCount(1, $errors);
         $this->assertSame('The source is already used.', $errors[0]->getMessage());

--- a/tests/Model/NotFoundTest.php
+++ b/tests/Model/NotFoundTest.php
@@ -24,7 +24,7 @@ class NotFoundTest extends TestCase
         $this->assertEqualsWithDelta(\time(), $notFound->getTimestamp()->format('U'), 1);
     }
 
-    public function pathProvider()
+    public function pathProvider(): array
     {
         return [
             ['foo/bar', '/foo/bar'],
@@ -39,16 +39,11 @@ class NotFoundTest extends TestCase
             ['foo/bar?baz=true', '/foo/bar'],
             ['http://www.example.com/foo?baz=bar&foo=baz', '/foo'],
             ['http://www.example.com/foo?baz=bar&foo=baz#baz', '/foo'],
-            ['', null],
-            ['   ', null],
             ['/', '/'],
         ];
     }
 
-    /**
-     * @return \Zenstruck\RedirectBundle\Model\NotFound
-     */
-    private function createNotFound($path, $fullUrl, $referer = null, ?\DateTime $timestamp = null)
+    private function createNotFound(string $path, string $fullUrl, ?string $referer = null, ?\DateTime $timestamp = null): \Zenstruck\RedirectBundle\Model\NotFound
     {
         return $this->getMockForAbstractClass(
             'Zenstruck\RedirectBundle\Model\NotFound',

--- a/tests/Model/RedirectTest.php
+++ b/tests/Model/RedirectTest.php
@@ -74,7 +74,7 @@ class RedirectTest extends TestCase
         $this->assertSame('/foo', $redirect->getSource());
     }
 
-    public function sourceProvider()
+    public function sourceProvider(): array
     {
         return [
             ['foo/bar', '/foo/bar'],
@@ -89,30 +89,21 @@ class RedirectTest extends TestCase
             ['foo/bar?baz=true', '/foo/bar'],
             ['http://www.example.com/foo?baz=bar&foo=baz', '/foo'],
             ['http://www.example.com/foo?baz=bar&foo=baz#baz', '/foo'],
-            ['', null],
-            ['   ', null],
             ['/', '/'],
         ];
     }
 
-    public function destinationProvider()
+    public function destinationProvider(): array
     {
         return [
             ['/foo', '/foo'],
             ['foo', '/foo'],
             ['foo?bar=baz', '/foo?bar=baz'],
-            [null, null],
-            ['', null],
-            [' ', null],
-            ['   ', null],
             ['http://www.example.com/foo', 'http://www.example.com/foo'],
         ];
     }
 
-    /**
-     * @return \Zenstruck\RedirectBundle\Model\Redirect
-     */
-    private function createRedirect($source, $destination, $permanent = true)
+    private function createRedirect(string $source, string $destination, bool $permanent = true): \Zenstruck\RedirectBundle\Model\Redirect
     {
         return $this->getMockForAbstractClass(
             'Zenstruck\RedirectBundle\Model\Redirect',

--- a/tests/Service/NotFoundManagerTest.php
+++ b/tests/Service/NotFoundManagerTest.php
@@ -15,9 +15,8 @@ class NotFoundManagerTest extends TestCase
 {
     public const NOT_FOUND_DUMMY_CLASS = 'Zenstruck\RedirectBundle\Tests\Fixture\Bundle\Entity\DummyNotFound';
 
-    /** @var MockObject&ObjectManager $om */
+    /** @var MockObject&ObjectManager */
     private $om;
-
 
     private NotFoundManager $notFoundManager;
 

--- a/tests/Service/NotFoundManagerTest.php
+++ b/tests/Service/NotFoundManagerTest.php
@@ -2,6 +2,8 @@
 
 namespace Zenstruck\RedirectBundle\Tests\Service;
 
+use Doctrine\Persistence\ObjectManager;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Zenstruck\RedirectBundle\Service\NotFoundManager;
@@ -13,17 +15,15 @@ class NotFoundManagerTest extends TestCase
 {
     public const NOT_FOUND_DUMMY_CLASS = 'Zenstruck\RedirectBundle\Tests\Fixture\Bundle\Entity\DummyNotFound';
 
+    /** @var MockObject&ObjectManager $om */
     private $om;
 
-    private $repository;
 
-    /** @var NotFoundManager */
-    private $notFoundManager;
+    private NotFoundManager $notFoundManager;
 
     protected function setUp(): void
     {
         $this->om = $this->createMock('Doctrine\Persistence\ObjectManager');
-        $this->repository = $this->createMock('Doctrine\Persistence\ObjectRepository');
 
         $this->notFoundManager = new NotFoundManager(self::NOT_FOUND_DUMMY_CLASS, $this->om);
     }

--- a/tests/Service/RedirectManagerTest.php
+++ b/tests/Service/RedirectManagerTest.php
@@ -16,10 +16,10 @@ class RedirectManagerTest extends TestCase
 {
     public const REDIRECT_DUMMY_CLASS = 'Zenstruck\RedirectBundle\Tests\Fixture\Bundle\Entity\DummyRedirect';
 
-    /** @var MockObject&ObjectManager $om */
+    /** @var MockObject&ObjectManager */
     private $om;
 
-    /** @var MockObject&ObjectRepository $repository */
+    /** @var MockObject&ObjectRepository */
     private $repository;
 
     private RedirectManager $redirectManager;

--- a/tests/Service/RedirectManagerTest.php
+++ b/tests/Service/RedirectManagerTest.php
@@ -2,6 +2,9 @@
 
 namespace Zenstruck\RedirectBundle\Tests\Service;
 
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectRepository;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Zenstruck\RedirectBundle\Service\RedirectManager;
 use Zenstruck\RedirectBundle\Tests\Fixture\Bundle\Entity\DummyRedirect;
@@ -13,12 +16,13 @@ class RedirectManagerTest extends TestCase
 {
     public const REDIRECT_DUMMY_CLASS = 'Zenstruck\RedirectBundle\Tests\Fixture\Bundle\Entity\DummyRedirect';
 
+    /** @var MockObject&ObjectManager $om */
     private $om;
 
+    /** @var MockObject&ObjectRepository $repository */
     private $repository;
 
-    /** @var RedirectManager */
-    private $redirectManager;
+    private RedirectManager $redirectManager;
 
     protected function setUp(): void
     {

--- a/tests/ZenstruckRedirectBundleTest.php
+++ b/tests/ZenstruckRedirectBundleTest.php
@@ -17,7 +17,6 @@ class ZenstruckRedirectBundleTest extends TestCase
     {
         $container = $this
             ->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
-            ->setMethods(['addCompilerPass'])
             ->getMock()
         ;
         $container

--- a/tests/ZenstruckRedirectBundleTest.php
+++ b/tests/ZenstruckRedirectBundleTest.php
@@ -17,6 +17,7 @@ class ZenstruckRedirectBundleTest extends TestCase
     {
         $container = $this
             ->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->setMethods(['addCompilerPass'])
             ->getMock()
         ;
         $container


### PR DESCRIPTION
I know it is maybe a bit early for dropping php 8. 
But as you are maintaining so many great bundles, it is better so be prepared.
Please have a look for BC breaks. As of course the strong types will be.

This is to fix the deprecation of NULL as Param in ltrim()
Code could be better, but it works.
https://github.com/kbond/ZenstruckRedirectBundle/compare/master...Chris53897:ZenstruckRedirectBundle:feature/drop-support-php-7.x?expand=1#diff-4ba8cd4a4825e89fd7af82dd6413ebd66fac5a052b1e1c811a147326d2578e0eR102

I thought about changing the EntityMapping from Annotations to Attributes. But this PR is already big.